### PR TITLE
Add: Add self-destruct command

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func run() (exitCode int) {
 			CurrentCommand,
 			WorkspaceCommand,
 			SelfUpgradeCommand,
+			SelfDestructCommand,
 		},
 		ExitErrHandler: func(c *cli.Context, err error) {
 			panic(err)

--- a/self_destruct.go
+++ b/self_destruct.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+var SelfDestructCommand = &cli.Command{
+	Name:    "self-destruct",
+	Usage:   "Uninstall the pj itself",
+	Aliases: []string{"self-uninstall"},
+	Action:  SelfDestructAction,
+}
+
+func SelfDestructAction(c *cli.Context) error {
+	cfg, err := NewConfig(c)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(cfg.DataDir)
+	if err != nil {
+		return err
+	}
+
+	cmdPath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	realCmdPath, err := filepath.EvalSymlinks(cmdPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(realCmdPath)
+	if err != nil {
+		return nil
+	}
+
+	return nil
+}

--- a/testdata/stdout/testrun_pj.golden
+++ b/testdata/stdout/testrun_pj.golden
@@ -8,14 +8,15 @@ VERSION:
    dev
 
 COMMANDS:
-   list          List projects
-   get           Get the project with the specified name
-   init          Initialize the project
-   change        Change the current project to the specified project
-   current       Get the current project
-   workspace     Subcommands for managing workspaces
-   self-upgrade  Upgrade the pj itself
-   help, h       Shows a list of commands or help for one command
+   list                           List projects
+   get                            Get the project with the specified name
+   init                           Initialize the project
+   change                         Change the current project to the specified project
+   current                        Get the current project
+   workspace                      Subcommands for managing workspaces
+   self-upgrade                   Upgrade the pj itself
+   self-destruct, self-uninstall  Uninstall the pj itself
+   help, h                        Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --data-dir value          specify the path to store the projects file (default: $XDG_DATA_HOME/pj) [$PJ_DATA_DIR]

--- a/testdata/stdout/testrun_pj_-h.golden
+++ b/testdata/stdout/testrun_pj_-h.golden
@@ -8,14 +8,15 @@ VERSION:
    dev
 
 COMMANDS:
-   list          List projects
-   get           Get the project with the specified name
-   init          Initialize the project
-   change        Change the current project to the specified project
-   current       Get the current project
-   workspace     Subcommands for managing workspaces
-   self-upgrade  Upgrade the pj itself
-   help, h       Shows a list of commands or help for one command
+   list                           List projects
+   get                            Get the project with the specified name
+   init                           Initialize the project
+   change                         Change the current project to the specified project
+   current                        Get the current project
+   workspace                      Subcommands for managing workspaces
+   self-upgrade                   Upgrade the pj itself
+   self-destruct, self-uninstall  Uninstall the pj itself
+   help, h                        Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --data-dir value          specify the path to store the projects file (default: $XDG_DATA_HOME/pj) [$PJ_DATA_DIR]


### PR DESCRIPTION
Remove the pj data dir and the pj itself.
If it was executed via a symlink, remove only the path where the symlink
was evaluated.